### PR TITLE
Fix missing mdoc, mso, & tests folders when installing on Windows.

### DIFF
--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -4,6 +4,8 @@ import hashlib
 import secrets
 import uuid
 
+from datetime import timezone
+
 from pycose.headers import Algorithm, KID
 from pycose.keys import CoseKey, EC2Key
 from pycose.messages import Sign1Message
@@ -137,7 +139,7 @@ class MsoIssuer(MsoX509Fabric):
         :return: the signed mso
         :rtype: Sign1Message
         """
-        utcnow = datetime.datetime.now(datetime.UTC)
+        utcnow = datetime.datetime.now(timezone.utc)
         if settings.PYMDOC_EXP_DELTA_HOURS:
             exp = utcnow + datetime.timedelta(
                 hours=settings.PYMDOC_EXP_DELTA_HOURS

--- a/pymdoccbor/mso/issuer.py
+++ b/pymdoccbor/mso/issuer.py
@@ -137,7 +137,7 @@ class MsoIssuer(MsoX509Fabric):
         :return: the signed mso
         :rtype: Sign1Message
         """
-        utcnow = datetime.datetime.utcnow()
+        utcnow = datetime.datetime.now(datetime.UTC)
         if settings.PYMDOC_EXP_DELTA_HOURS:
             exp = utcnow + datetime.timedelta(
                 hours=settings.PYMDOC_EXP_DELTA_HOURS

--- a/pymdoccbor/settings.py
+++ b/pymdoccbor/settings.py
@@ -34,11 +34,11 @@ X509_LOCALITY_NAME          = os.getenv('X509_LOCALITY_NAME', u"San Francisco")
 X509_ORGANIZATION_NAME      = os.getenv('X509_ORGANIZATION_NAME', u"My Company")
 X509_COMMON_NAME            = os.getenv('X509_COMMON_NAME', u"mysite.com")
 
-X509_NOT_VALID_BEFORE       = os.getenv('X509_NOT_VALID_BEFORE', datetime.datetime.utcnow())
+X509_NOT_VALID_BEFORE       = os.getenv('X509_NOT_VALID_BEFORE', datetime.datetime.now(datetime.UTC))
 X509_NOT_VALID_AFTER_DAYS   = os.getenv('X509_NOT_VALID_AFTER_DAYS', 10)
 X509_NOT_VALID_AFTER        = os.getenv(
     'X509_NOT_VALID_AFTER', 
-    datetime.datetime.utcnow() + datetime.timedelta(
+    datetime.datetime.now(datetime.UTC) + datetime.timedelta(
         days=X509_NOT_VALID_AFTER_DAYS
     )
 )

--- a/pymdoccbor/settings.py
+++ b/pymdoccbor/settings.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from datetime import timezone
+
 COSEKEY_HAZMAT_CRV_MAP = {
     "secp256r1": "P_256",
     "secp384r1": "P_384",
@@ -34,11 +36,11 @@ X509_LOCALITY_NAME          = os.getenv('X509_LOCALITY_NAME', u"San Francisco")
 X509_ORGANIZATION_NAME      = os.getenv('X509_ORGANIZATION_NAME', u"My Company")
 X509_COMMON_NAME            = os.getenv('X509_COMMON_NAME', u"mysite.com")
 
-X509_NOT_VALID_BEFORE       = os.getenv('X509_NOT_VALID_BEFORE', datetime.datetime.now(datetime.UTC))
+X509_NOT_VALID_BEFORE       = os.getenv('X509_NOT_VALID_BEFORE', datetime.datetime.now(timezone.utc))
 X509_NOT_VALID_AFTER_DAYS   = os.getenv('X509_NOT_VALID_AFTER_DAYS', 10)
 X509_NOT_VALID_AFTER        = os.getenv(
     'X509_NOT_VALID_AFTER', 
-    datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+    datetime.datetime.now(timezone.utc) + datetime.timedelta(
         days=X509_NOT_VALID_AFTER_DAYS
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     author='Giuseppe De Marco',
     author_email='demarcog83@gmail.com',
     license='Apache Software License',
-    packages=find_packages(include=["pymdoccbor", "pymdoccbor.*"]),  # ✅ Detect all subpackages
-    include_package_data=True,  # ✅ Include data files
+    packages=find_packages(include=["pymdoccbor", "pymdoccbor.*"]),
+    include_package_data=True,
     install_requires=[
         'cbor2>=5.4.0,<5.5.0',
         'cwt>=2.3.0,<2.4',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import re
-
-from glob import glob
-from setuptools import setup
+from setuptools import setup, find_packages
 
 def readme():
     with open('README.md') as f:
@@ -31,15 +29,9 @@ setup(
     url='https://github.com/peppelinux/pyMDL-MDOC',
     author='Giuseppe De Marco',
     author_email='demarcog83@gmail.com',
-    license='License :: OSI Approved :: Apache Software License',
-    # scripts=[f'{_pkg_name}/bin/{_pkg_name}'],
-    packages=[f"{_pkg_name}"],
-    package_dir={f"{_pkg_name}": f"{_pkg_name}"},
-    package_data={f"{_pkg_name}": [
-            i.replace(f'{_pkg_name}/', '')
-            for i in glob(f'{_pkg_name}/**', recursive=True)
-        ]
-    },
+    license='Apache Software License',
+    packages=find_packages(include=["pymdoccbor", "pymdoccbor.*"]),  # ✅ Detect all subpackages
+    include_package_data=True,  # ✅ Include data files
     install_requires=[
         'cbor2>=5.4.0,<5.5.0',
         'cwt>=2.3.0,<2.4',


### PR DESCRIPTION
When installing on Windows with `pip install git+https://github.com/IdentityPython/pyMDOC-CBOR.git` the mdoc, mso, and tests folders are missing from the installation leading to mdoc failures. This PR fixes the issue by updating the sub-packages detection in the setup.py file.

- Updated sub-package detection in setup.py
- Replaced deprecated utcnow calls causing warnings when running tests
- Added `__init__.py` files to mdoc sub-package to aid detection

`pytest --pyargs pymdoccbor.tests` passes all tests without warnings