### PR TITLE
Status claim support

### DIFF
--- a/pymdoccbor/mdoc/exceptions.py
+++ b/pymdoccbor/mdoc/exceptions.py
@@ -9,3 +9,6 @@ class NoSignedDocumentProvided(Exception):
 
 class MissingIssuerAuth(Exception):
     pass
+
+class InvalidStatusDescriptor(Exception):
+    pass

--- a/pymdoccbor/mdoc/issuer.py
+++ b/pymdoccbor/mdoc/issuer.py
@@ -11,6 +11,7 @@ from typing import Union
 from pymdoccbor.mso.issuer import MsoIssuer
 
 from cbor_diag import cbor2diag
+from pymdoccbor.mdoc.exceptions import InvalidStatusDescriptor
 
 
 logger = logging.getLogger("pymdoccbor")
@@ -74,7 +75,8 @@ class MdocCborIssuer:
         validity: dict = None,
         devicekeyinfo: Union[dict, CoseKey, str] = None,
         cert_path: str = None,
-        revocation: dict = None
+        revocation: dict = None,
+        status: dict = None
     ) -> dict:
         """
         create a new mdoc with signed mso
@@ -85,6 +87,7 @@ class MdocCborIssuer:
         :param devicekeyinfo: Union[dict, CoseKey, str]: device key info
         :param cert_path: str: path to the certificate
         :param revocation: dict: revocation status dict it may include status_list and identifier_list keys
+        :param status: dict: status dict that includes the status list's uri and the idx following the "https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list" specification
 
         :return: dict: signed mdoc
         """
@@ -187,6 +190,17 @@ class MdocCborIssuer:
             ],
             "status": self.status,
         }
+
+        if status:
+            if not "status_list" in status:
+                raise InvalidStatusDescriptor("status_list is required")
+
+            if not "uri" in status["status_list"]:
+                raise InvalidStatusDescriptor("uri is required")
+            if not "idx" in status["status_list"]:
+                raise InvalidStatusDescriptor("idx is required")
+
+            res["status"] = status
 
         logger.debug(f"MSO diagnostic notation: {cbor2diag(mso_cbor)}")
 

--- a/pymdoccbor/mdoc/verifier.py
+++ b/pymdoccbor/mdoc/verifier.py
@@ -200,6 +200,8 @@ class MdocCbor:
 
             doc_cnt += 1
 
+        self.status = cdict.get('status', None)
+
         return False if self.documents_invalid else True
 
     def __repr__(self) -> str:

--- a/pymdoccbor/tests/test_08_mdoc_cbor.py
+++ b/pymdoccbor/tests/test_08_mdoc_cbor.py
@@ -18,6 +18,12 @@ def test_mdoc_cbor_creation():
             "issuance_date": "2024-12-31",
             "expiry_date": "2050-12-31"
         },
+        status={
+            "status_list": {
+                "idx": 412,
+                "uri": "https://example.com/statuslists/1"
+            }
+        }
     )
 
     data = cbor2.dumps(mdoc)  
@@ -29,3 +35,72 @@ def test_mdoc_cbor_creation():
     assert mdoc
     assert 'org.micov.medical.1' in mdocp.disclosure_map
     assert mdocp.disclosure_map == MICOV_DATA
+    assert mdocp.status == {
+        "status_list": {
+            "idx": 412,
+            "uri": "https://example.com/statuslists/1"
+        }
+    }
+
+def test_mdoc_cbor_invalid_status():
+    mdoci = MdocCborIssuer(
+        private_key=PKEY,
+        alg="ES256",
+    )
+
+    try:
+        mdoci.new(
+            data=MICOV_DATA,
+            #devicekeyinfo=PKEY,  # TODO
+            doctype="org.micov.medical.1",
+            validity={
+                "issuance_date": "2024-12-31",
+                "expiry_date": "2050-12-31"
+            },
+            status={
+                "status_list": {
+                    "idx": 412,
+                    # "uri": "https://example.com/statuslists/1"  # Missing URI
+                }
+            }
+        )
+    except Exception as e:
+        assert str(e) == "uri is required"
+
+    try:
+        mdoci.new(
+            data=MICOV_DATA,
+            #devicekeyinfo=PKEY,  # TODO
+            doctype="org.micov.medical.1",
+            validity={
+                "issuance_date": "2024-12-31",
+                "expiry_date": "2050-12-31"
+            },
+            status={
+                "status_list": {
+                    #"idx": 412,
+                    "uri": "https://example.com/statuslists/1"  # Missing URI
+                }
+            }
+        )
+    except Exception as e:
+        assert str(e) == "idx is required"
+
+    try:
+        mdoci.new(
+            data=MICOV_DATA,
+            #devicekeyinfo=PKEY,  # TODO
+            doctype="org.micov.medical.1",
+            validity={
+                "issuance_date": "2024-12-31",
+                "expiry_date": "2050-12-31"
+            },
+            status={
+                "not_status_list": {
+                    "idx": 412,
+                    "uri": "https://example.com/statuslists/1"  # Missing URI
+                }
+            }
+        )
+    except Exception as e:
+        assert str(e) == "status_list is required"


### PR DESCRIPTION
Adds the support to the status claim as described [https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-10.html#name-referenced-token-in-cose](here)